### PR TITLE
hotfix: add dataset loading to examples 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ To use the API, follow these steps:
    ```
 
 2. Initialize the FedotAI object. The required parameters are the following: 
-* `dataset` path to folder containing dataset files or pre-loaded dataset object
+* `dataset` native `fedot_llm.data.data.Dataset` object containing dataset files (can be initialized from a specified path to a dataset)
 * `model` chat model to use (currently ollama and custom request based models are supported)
 * `output` output type ('jupyter' for live updated status report and 'debug' for a feed of all langchain events)
 
 To acquire predictions, use the `predict` method with a string description of the dataset and associated task in an arbitrary form.
    ```
    fedot_ai =  FedotAI(
-         dataset=dataset_path,
+         dataset=PathDatasetLoader.load(dataset_path),
          model=init_chat_model(
                            model="llama3.1",
                            model_provider='ollama'),

--- a/examples/by_datasets/health_insurance.ipynb
+++ b/examples/by_datasets/health_insurance.ipynb
@@ -35,7 +35,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_path = '../../datasets/Health_Insurance'"
+    "from pathlib import Path\n",
+    "from fedot_llm.data.loaders import PathDatasetLoader\n",
+    "\n",
+    "dataset_path = Path(module_path) / 'datasets' / 'Health_Insurance'\n",
+    "dataset = PathDatasetLoader.load(dataset_path)"
    ]
   },
   {
@@ -100,7 +104,7 @@
    ],
    "source": [
     "fedot_ai =  FedotAI(\n",
-    "        dataset=dataset_path,\n",
+    "        dataset=dataset,\n",
     "        model=init_chat_model(\n",
     "                        model=\"llama3.1\",\n",
     "                        model_provider='ollama'),\n",

--- a/examples/by_datasets/health_insurance_ru.ipynb
+++ b/examples/by_datasets/health_insurance_ru.ipynb
@@ -35,7 +35,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_path = '../../datasets/Health_Insurance'"
+    "from pathlib import Path\n",
+    "from fedot_llm.data.loaders import PathDatasetLoader\n",
+    "\n",
+    "dataset_path = Path(module_path) / 'datasets' / 'Health_Insurance'\n",
+    "dataset = PathDatasetLoader.load(dataset_path)"
    ]
   },
   {
@@ -117,7 +121,7 @@
    ],
    "source": [
     "fedot_ai =  FedotAI(\n",
-    "        dataset=dataset_path,\n",
+    "        dataset=dataset,\n",
     "        model=init_chat_model(\n",
     "                        model=\"llama3.1\",\n",
     "                        model_provider='ollama'),\n",


### PR DESCRIPTION
## Summary

- [x] add dataset loading cells to a health_insurance examples (4d19c1b)
- [x] update a `README.md` section of `FedotAI` initialization example (b267c94)

## Context

These changes ensure that the pynb examples function properly. The dataset should be injected in the `FedotAI` constructor as an instance of the `fedot_llm.data.data.Dataset`, rather than as a string representing the path to the dataset folder.
